### PR TITLE
fix anthropic submit tool outputs

### DIFF
--- a/examples/prisma-nextjs/src/app/api/anthropic/poll/route.ts
+++ b/examples/prisma-nextjs/src/app/api/anthropic/poll/route.ts
@@ -76,9 +76,9 @@ export const GET = async () => {
   const toolCallId = run.required_action.submit_tool_outputs.tool_calls[0].id
 
   await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     run.id,
     {
+      thread_id: thread.id,
       tool_outputs: [
         {
           tool_call_id: toolCallId,

--- a/examples/prisma-nextjs/src/app/api/anthropic/stream/route.ts
+++ b/examples/prisma-nextjs/src/app/api/anthropic/stream/route.ts
@@ -106,9 +106,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submitToolOutputsRun = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {

--- a/packages/supercompat/tests/submitToolOutputsSignature.test.ts
+++ b/packages/supercompat/tests/submitToolOutputsSignature.test.ts
@@ -1,0 +1,27 @@
+import { test } from 'node:test'
+import { strict as assert } from 'node:assert'
+import Anthropic from '@anthropic-ai/sdk'
+import OpenAI from 'openai'
+import {
+  supercompat,
+  anthropicClientAdapter,
+  openaiResponsesStorageAdapter,
+  completionsRunAdapter,
+} from '../src/index'
+
+test('submitToolOutputs requires thread_id in params', async () => {
+  const client = supercompat({
+    client: anthropicClientAdapter({ anthropic: new Anthropic({ apiKey: 'test' }) }),
+    storage: openaiResponsesStorageAdapter({ openai: new OpenAI({ apiKey: process.env.TEST_OPENAI_API_KEY }) }),
+    runAdapter: completionsRunAdapter(),
+  })
+
+  await assert.rejects(
+    async () =>
+      client.beta.threads.runs.submitToolOutputs('run-id', {
+        stream: true,
+        tool_outputs: [],
+      }),
+    /invalid segments/
+  )
+})


### PR DESCRIPTION
## Summary
- fix Anthropics example to use runId-first submitToolOutputs
- cover missing thread_id case in tests

## Testing
- `npm run lint`
- `npm run lint:ts`
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68ab3bf207088322b31a5eee0ef78c23