### PR TITLE
fix submitToolOutputs signature in examples

### DIFF
--- a/examples/prisma-nextjs/src/app/api/azure-openai/stream/assistants-api-storage/route.ts
+++ b/examples/prisma-nextjs/src/app/api/azure-openai/stream/assistants-api-storage/route.ts
@@ -92,9 +92,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submitToolOutputsRun = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {

--- a/examples/prisma-nextjs/src/app/api/azure-openai/stream/route.ts
+++ b/examples/prisma-nextjs/src/app/api/azure-openai/stream/route.ts
@@ -87,9 +87,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submitToolOutputsRun = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {

--- a/examples/prisma-nextjs/src/app/api/google/poll/route.ts
+++ b/examples/prisma-nextjs/src/app/api/google/poll/route.ts
@@ -78,9 +78,9 @@ export const GET = async () => {
   const toolCallId = run.required_action.submit_tool_outputs.tool_calls[0].id
 
   await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     run.id,
     {
+      thread_id: thread.id,
       tool_outputs: [
         {
           tool_call_id: toolCallId,

--- a/examples/prisma-nextjs/src/app/api/google/stream/route.ts
+++ b/examples/prisma-nextjs/src/app/api/google/stream/route.ts
@@ -87,9 +87,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submitToolOutputsRun = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {

--- a/examples/prisma-nextjs/src/app/api/groq/poll/route.ts
+++ b/examples/prisma-nextjs/src/app/api/groq/poll/route.ts
@@ -76,9 +76,9 @@ export const GET = async () => {
   const toolCallId = run.required_action.submit_tool_outputs.tool_calls[0].id
 
   await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     run.id,
     {
+      thread_id: thread.id,
       tool_outputs: [
         {
           tool_call_id: toolCallId,

--- a/examples/prisma-nextjs/src/app/api/groq/stream/route.ts
+++ b/examples/prisma-nextjs/src/app/api/groq/stream/route.ts
@@ -85,9 +85,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submitToolOutputsRun = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {

--- a/examples/prisma-nextjs/src/app/api/mistral/poll/route.ts
+++ b/examples/prisma-nextjs/src/app/api/mistral/poll/route.ts
@@ -78,9 +78,9 @@ export const GET = async () => {
   const toolCallId = run.required_action.submit_tool_outputs.tool_calls[0].id
 
   await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     run.id,
     {
+      thread_id: thread.id,
       tool_outputs: [
         {
           tool_call_id: toolCallId,

--- a/examples/prisma-nextjs/src/app/api/mistral/stream/route.ts
+++ b/examples/prisma-nextjs/src/app/api/mistral/stream/route.ts
@@ -87,9 +87,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submitToolOutputsRun = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {

--- a/examples/prisma-nextjs/src/app/api/openai-responses-prisma/poll/route.ts
+++ b/examples/prisma-nextjs/src/app/api/openai-responses-prisma/poll/route.ts
@@ -70,9 +70,9 @@ export const GET = async () => {
   const toolCallId = run.required_action.submit_tool_outputs.tool_calls[0].id
 
   await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     run.id,
     {
+      thread_id: thread.id,
       tool_outputs: [
         {
           tool_call_id: toolCallId,

--- a/examples/prisma-nextjs/src/app/api/openai-responses-prisma/stream/route.ts
+++ b/examples/prisma-nextjs/src/app/api/openai-responses-prisma/stream/route.ts
@@ -79,9 +79,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submit = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {

--- a/examples/prisma-nextjs/src/app/api/openai-responses/poll/route.ts
+++ b/examples/prisma-nextjs/src/app/api/openai-responses/poll/route.ts
@@ -69,9 +69,9 @@ export const GET = async () => {
   const toolCallId = run.required_action.submit_tool_outputs.tool_calls[0].id
 
   await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     run.id,
     {
+      thread_id: thread.id,
       tool_outputs: [
         {
           tool_call_id: toolCallId,

--- a/examples/prisma-nextjs/src/app/api/openai-responses/stream/route.ts
+++ b/examples/prisma-nextjs/src/app/api/openai-responses/stream/route.ts
@@ -78,9 +78,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submit = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {

--- a/examples/prisma-nextjs/src/app/api/openai/poll/assistants-api-storage/route.ts
+++ b/examples/prisma-nextjs/src/app/api/openai/poll/assistants-api-storage/route.ts
@@ -78,9 +78,9 @@ export const GET = async () => {
   const toolCallId = run.required_action.submit_tool_outputs.tool_calls[0].id
 
   await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     run.id,
     {
+      thread_id: thread.id,
       tool_outputs: [
         {
           tool_call_id: toolCallId,

--- a/examples/prisma-nextjs/src/app/api/openai/poll/route.ts
+++ b/examples/prisma-nextjs/src/app/api/openai/poll/route.ts
@@ -77,9 +77,9 @@ export const GET = async () => {
   const toolCallId = run.required_action.submit_tool_outputs.tool_calls[0].id
 
   await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     run.id,
     {
+      thread_id: thread.id,
       tool_outputs: [
         {
           tool_call_id: toolCallId,

--- a/examples/prisma-nextjs/src/app/api/openai/stream/assistants-api-storage/o1/route.ts
+++ b/examples/prisma-nextjs/src/app/api/openai/stream/assistants-api-storage/o1/route.ts
@@ -87,9 +87,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submitToolOutputsRun = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {

--- a/examples/prisma-nextjs/src/app/api/openai/stream/assistants-api-storage/route.ts
+++ b/examples/prisma-nextjs/src/app/api/openai/stream/assistants-api-storage/route.ts
@@ -87,9 +87,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submitToolOutputsRun = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {

--- a/examples/prisma-nextjs/src/app/api/openai/stream/route.ts
+++ b/examples/prisma-nextjs/src/app/api/openai/stream/route.ts
@@ -92,9 +92,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submitToolOutputsRun = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {

--- a/examples/prisma-nextjs/src/app/api/perplexity/poll/route.ts
+++ b/examples/prisma-nextjs/src/app/api/perplexity/poll/route.ts
@@ -78,9 +78,9 @@ export const GET = async () => {
   const toolCallId = run.required_action.submit_tool_outputs.tool_calls[0].id
 
   await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     run.id,
     {
+      thread_id: thread.id,
       tool_outputs: [
         {
           tool_call_id: toolCallId,

--- a/examples/prisma-nextjs/src/app/api/perplexity/stream/route.ts
+++ b/examples/prisma-nextjs/src/app/api/perplexity/stream/route.ts
@@ -87,9 +87,9 @@ export const GET = async () => {
   const toolCallId = requiresActionEvent.data.required_action?.submit_tool_outputs.tool_calls[0].id
 
   const submitToolOutputsRun = await client.beta.threads.runs.submitToolOutputs(
-    thread.id,
     requiresActionEvent.data.id,
     {
+      thread_id: thread.id,
       stream: true,
       tool_outputs: [
         {


### PR DESCRIPTION
## Summary
- update example routes to call submitToolOutputs with run id and thread_id in params object

## Testing
- `npm run lint`
- `npm run lint:ts`
- `npm run test` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68ab484048c48322a5695dad0be9eaa7