### PR TITLE
Revert proxy setup and poll anthropic tool runs

### DIFF
--- a/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadMessageCompleted.ts
+++ b/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadMessageCompleted.ts
@@ -14,9 +14,9 @@ export const threadMessageCompleted = async ({
 }: {
   prisma: PrismaClient
   event: OpenAI.Beta.AssistantStreamEvent.ThreadMessageCompleted
-  controller: ReadableStreamDefaultController<OpenAI.Beta.AssistantStreamEvent.ThreadMessageCompleted>
+  controller: ReadableStreamDefaultController<string>
 }) => {
-  controller.enqueue(event)
+  controller.enqueue(`data: ${JSON.stringify(event)}\n\n`)
 
   const data = event.data as MessageWithToolCalls
 

--- a/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadMessageCreated.ts
+++ b/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadMessageCreated.ts
@@ -18,7 +18,7 @@ export const threadMessageCreated = async ({
 }: {
   prisma: PrismaClient
   event: OpenAI.Beta.AssistantStreamEvent.ThreadMessageCreated
-  controller: ReadableStreamDefaultController<OpenAI.Beta.AssistantStreamEvent.ThreadMessageCreated>
+  controller: ReadableStreamDefaultController<string>
 }) => {
   const message = await prisma.message.create({
     data: {
@@ -33,10 +33,10 @@ export const threadMessageCreated = async ({
 
   const serializedMessage = serializeMessage({ message })
 
-  controller.enqueue({
+  controller.enqueue(`data: ${JSON.stringify({
     ...event,
     data: serializedMessage,
-  })
+  })}\n\n`)
 
   return serializedMessage
 }

--- a/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadMessageDelta.ts
+++ b/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadMessageDelta.ts
@@ -5,7 +5,7 @@ export const threadMessageDelta = ({
   controller,
 }: {
   event: OpenAI.Beta.AssistantStreamEvent.ThreadMessageDelta
-  controller: ReadableStreamDefaultController<OpenAI.Beta.AssistantStreamEvent.ThreadMessageDelta>
+  controller: ReadableStreamDefaultController<string>
 }) => (
-  controller.enqueue(event)
+  controller.enqueue(`data: ${JSON.stringify(event)}\n\n`)
 )

--- a/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunCompleted.ts
+++ b/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunCompleted.ts
@@ -9,9 +9,9 @@ export const threadRunCompleted = async ({
 }: {
   prisma: PrismaClient
   event: OpenAI.Beta.AssistantStreamEvent.ThreadRunCompleted
-  controller: ReadableStreamDefaultController<OpenAI.Beta.AssistantStreamEvent.ThreadRunCompleted>
+  controller: ReadableStreamDefaultController<string>
 }) => {
-  controller.enqueue(event)
+  controller.enqueue(`data: ${JSON.stringify(event)}\n\n`)
 
   const runRecord = await prisma.run.update({
     where: {

--- a/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunFailed.ts
+++ b/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunFailed.ts
@@ -9,9 +9,9 @@ export const threadRunFailed = async ({
 }: {
   prisma: PrismaClient
   event: OpenAI.Beta.AssistantStreamEvent.ThreadRunFailed
-  controller: ReadableStreamDefaultController<OpenAI.Beta.AssistantStreamEvent.ThreadRunFailed>
+  controller: ReadableStreamDefaultController<string>
 }) => {
-  controller.enqueue(event)
+  controller.enqueue(`data: ${JSON.stringify(event)}\n\n`)
 
     const runRecord = await prisma.run.update({
       where: {

--- a/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunInProgress.ts
+++ b/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunInProgress.ts
@@ -9,9 +9,9 @@ export const threadRunInProgress = ({
 }: {
   prisma: PrismaClient
   event: OpenAI.Beta.AssistantStreamEvent.ThreadRunInProgress
-  controller: ReadableStreamDefaultController<OpenAI.Beta.AssistantStreamEvent.ThreadRunInProgress>
+  controller: ReadableStreamDefaultController<string>
 }) => {
-  controller.enqueue(event)
+  controller.enqueue(`data: ${JSON.stringify(event)}\n\n`)
 
   return prisma.run.update({
     where: {

--- a/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunRequiresAction.ts
+++ b/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunRequiresAction.ts
@@ -9,9 +9,9 @@ export const threadRunRequiresAction = async ({
 }: {
   prisma: PrismaClient
   event: OpenAI.Beta.AssistantStreamEvent.ThreadRunRequiresAction
-  controller: ReadableStreamDefaultController<OpenAI.Beta.AssistantStreamEvent.ThreadRunRequiresAction>
+  controller: ReadableStreamDefaultController<string>
 }) => {
-  controller.enqueue(event)
+  controller.enqueue(`data: ${JSON.stringify(event)}\n\n`)
 
     const runRecord = await prisma.run.update({
       where: {

--- a/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunStepCreated.ts
+++ b/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunStepCreated.ts
@@ -27,7 +27,7 @@ export const threadRunStepCreated = async ({
 }: {
   prisma: PrismaClient
   event: OpenAI.Beta.AssistantStreamEvent.ThreadRunStepCreated
-  controller: ReadableStreamDefaultController<OpenAI.Beta.AssistantStreamEvent.ThreadRunStepCreated>
+  controller: ReadableStreamDefaultController<string>
 }) => {
     const runStep = await prisma.runStep.create({
       data: {
@@ -43,10 +43,10 @@ export const threadRunStepCreated = async ({
 
     const serializedRunStep = serializeRunStep({ runStep })
 
-    controller.enqueue({
+    controller.enqueue(`data: ${JSON.stringify({
       ...event,
       data: serializedRunStep as any,
-    })
+    })}\n\n`)
 
     return serializedRunStep as any
   }

--- a/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunStepDelta.ts
+++ b/packages/supercompat/src/adapters/storage/prismaStorageAdapter/threads/runs/onEvent/handlers/threadRunStepDelta.ts
@@ -5,7 +5,7 @@ export const threadRunStepDelta = ({
   controller,
 }: {
   event: OpenAI.Beta.AssistantStreamEvent.ThreadRunStepDelta
-  controller: ReadableStreamDefaultController<OpenAI.Beta.AssistantStreamEvent.ThreadRunStepDelta>
+  controller: ReadableStreamDefaultController<string>
 }) => (
-  controller.enqueue(event)
+  controller.enqueue(`data: ${JSON.stringify(event)}\n\n`)
 )


### PR DESCRIPTION
## Summary
- stream anthropic tool call runs instead of polling
- emit SSE-formatted events from Prisma storage adapter

## Testing
- `npm run lint`
- `npm run lint:ts`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68ae5a93faf88322a44b54ad39c5746f