### PR TITLE
fix streaming message IDs and add multi-message test

### DIFF
--- a/packages/supercompat/src/adapters/run/completionsRunAdapter/index.ts
+++ b/packages/supercompat/src/adapters/run/completionsRunAdapter/index.ts
@@ -112,10 +112,11 @@ export const completionsRunAdapter = () => async ({
     })
   }
 
+  const messageId = uid(24)
   let message = await onEvent({
     event: 'thread.message.created',
     data: {
-      id: 'THERE_IS_A_BUG_IN_SUPERCOMPAT_IF_YOU_SEE_THIS_ID',
+      id: messageId,
       object: 'thread.message',
       completed_at: null,
       run_id: run.id,
@@ -132,10 +133,11 @@ export const completionsRunAdapter = () => async ({
     },
   })
 
+  const messageRunStepId = uid(24)
   onEvent({
     event: 'thread.run.step.created',
     data: {
-      id: 'THERE_IS_A_BUG_IN_SUPERCOMPAT_IF_YOU_SEE_THIS_ID',
+      id: messageRunStepId,
       object: 'thread.run.step',
       run_id: run.id,
       assistant_id: run.assistant_id,
@@ -176,10 +178,11 @@ export const completionsRunAdapter = () => async ({
 
     if (delta.tool_calls) {
       if (!toolCallsRunStep) {
+        const toolRunStepId = uid(24)
         toolCallsRunStep = await onEvent({
           event: 'thread.run.step.created',
           data: {
-            id: 'THERE_IS_A_BUG_IN_SUPERCOMPAT_IF_YOU_SEE_THIS_ID',
+            id: toolRunStepId,
             object: 'thread.run.step',
             run_id: run.id,
             assistant_id: run.assistant_id,

--- a/packages/supercompat/src/adapters/run/responsesRunAdapter/index.ts
+++ b/packages/supercompat/src/adapters/run/responsesRunAdapter/index.ts
@@ -102,10 +102,11 @@ export const responsesRunAdapter =
       })
     }
 
+    const messageId = uid(24)
     let message = (await onEvent({
       event: 'thread.message.created',
       data: {
-        id: 'THERE_IS_A_BUG_IN_SUPERCOMPAT_IF_YOU_SEE_THIS_ID',
+        id: messageId,
         object: 'thread.message',
         completed_at: null,
         run_id: run.id,
@@ -122,10 +123,11 @@ export const responsesRunAdapter =
       },
     })) as MessageWithToolCalls
 
+    const messageRunStepId = uid(24)
     onEvent({
       event: 'thread.run.step.created',
       data: {
-        id: 'THERE_IS_A_BUG_IN_SUPERCOMPAT_IF_YOU_SEE_THIS_ID',
+        id: messageRunStepId,
         object: 'thread.run.step',
         run_id: run.id,
         assistant_id: run.assistant_id,
@@ -189,10 +191,11 @@ export const responsesRunAdapter =
         case 'response.output_item.added': {
           if (event.item.type === 'function_call') {
             if (!toolCallsRunStep) {
+              const toolRunStepId = uid(24)
               toolCallsRunStep = (await onEvent({
                 event: 'thread.run.step.created',
                 data: {
-                  id: 'THERE_IS_A_BUG_IN_SUPERCOMPAT_IF_YOU_SEE_THIS_ID',
+                  id: toolRunStepId,
                   object: 'thread.run.step',
                   run_id: run.id,
                   assistant_id: run.assistant_id,

--- a/packages/supercompat/src/adapters/storage/openaiResponsesStorageAdapter/threads/messages/post.ts
+++ b/packages/supercompat/src/adapters/storage/openaiResponsesStorageAdapter/threads/messages/post.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai'
 import { messagesRegexp } from '@/lib/messages/messagesRegexp'
 import dayjs from 'dayjs'
+import { uid } from 'radash'
 
 export const post = ({ openai }: { openai: OpenAI }) => async (
   urlString: string,
@@ -32,7 +33,7 @@ export const post = ({ openai }: { openai: OpenAI }) => async (
 
   return new Response(
     JSON.stringify({
-      id: `msg_${Date.now()}`,
+      id: uid(24),
       object: 'thread.message',
       created_at: dayjs().unix(),
       thread_id: openaiConversationId,

--- a/packages/supercompat/src/adapters/storage/openaiResponsesStorageAdapter/threads/runs/post.ts
+++ b/packages/supercompat/src/adapters/storage/openaiResponsesStorageAdapter/threads/runs/post.ts
@@ -75,7 +75,7 @@ export const post =
       } else if (event.event === 'thread.run.step.created') {
         const step = {
           ...event.data,
-          id: `run_step_${uid(24)}`,
+          id: uid(24),
         } as OpenAI.Beta.Threads.Runs.RunStep
         runSteps.push(step)
         return step

--- a/packages/supercompat/tests/responsesStreamingMultipleMessages.test.ts
+++ b/packages/supercompat/tests/responsesStreamingMultipleMessages.test.ts
@@ -1,0 +1,79 @@
+import { test } from 'node:test'
+import { strict as assert } from 'node:assert'
+import OpenAI from 'openai'
+import { ProxyAgent, setGlobalDispatcher } from 'undici'
+import { HttpsProxyAgent } from 'https-proxy-agent'
+import {
+  responsesRunAdapter,
+  openaiClientAdapter,
+  supercompat,
+  openaiResponsesStorageAdapter,
+} from '../src/index'
+
+const apiKey = process.env.TEST_OPENAI_API_KEY
+
+if (process.env.HTTPS_PROXY) {
+  setGlobalDispatcher(new ProxyAgent(process.env.HTTPS_PROXY))
+}
+
+test('responsesRunAdapter streams multiple messages in same thread', async () => {
+  const realOpenAI = new OpenAI({
+    apiKey,
+    ...(process.env.HTTPS_PROXY
+      ? { httpAgent: new HttpsProxyAgent(process.env.HTTPS_PROXY) }
+      : {}),
+  })
+
+  const client = supercompat({
+    client: openaiClientAdapter({ openai: realOpenAI }),
+    runAdapter: responsesRunAdapter(),
+    storage: openaiResponsesStorageAdapter({ openai: realOpenAI }),
+  })
+
+  const assistant = await client.beta.assistants.create({
+    model: 'gpt-4o-mini',
+    instructions: 'You are a helpful assistant.',
+  })
+
+  const thread = await client.beta.threads.create()
+
+  await client.beta.threads.messages.create(thread.id, {
+    role: 'user',
+    content: 'Hello',
+  })
+
+  const run1 = await client.beta.threads.runs.create(thread.id, {
+    assistant_id: assistant.id,
+    stream: true,
+  })
+
+  for await (const _event of run1) {
+  }
+
+  await client.beta.threads.messages.create(thread.id, {
+    role: 'user',
+    content: 'Give me a short greeting',
+  })
+
+  const run2 = await client.beta.threads.runs.create(thread.id, {
+    assistant_id: assistant.id,
+    stream: true,
+  })
+
+  for await (const _event of run2) {
+  }
+
+  const list = await client.beta.threads.messages.list(thread.id)
+  const assistantMessages = list.data.filter((m) => m.role === 'assistant')
+  assert.ok(assistantMessages.length >= 2)
+  const secondAssistant = assistantMessages.at(-1)
+  const text = (
+    secondAssistant?.content[0] as OpenAI.Beta.Threads.MessageContentText
+  ).text.value
+    .trim()
+  assert.ok(text.length > 0)
+  assert.notEqual(
+    secondAssistant?.id,
+    'THERE_IS_A_BUG_IN_SUPERCOMPAT_IF_YOU_SEE_THIS_ID',
+  )
+})


### PR DESCRIPTION
## Summary
- generate unique message and run step IDs using `uid`
- test streaming responses with multiple messages in a single thread

## Testing
- `npm run lint`
- `npm run lint:ts`
- `npm run test` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_68ae799f52f08322afe9745c37b19b6b